### PR TITLE
Add base index page template

### DIFF
--- a/.github/workflows/marp-to-pages.yml
+++ b/.github/workflows/marp-to-pages.yml
@@ -35,6 +35,15 @@ jobs:
       - name: Create build directory
         run: mkdir -p build
 
+      - name: Copy index page
+        run: |
+          cp index.html build/
+          
+          # Update paths for preview if needed
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            sed -i "s|metadata.json|pr-preview/${{ github.event.number }}/metadata.json|g" build/index.html
+          fi
+
       - name: Process markdown files and generate metadata
         id: process
         run: |
@@ -135,6 +144,25 @@ jobs:
             echo "has_changes=true" >> $GITHUB_OUTPUT
           else
             echo "has_changes=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Validate build
+        run: |
+          # Check if required files exist
+          if [[ ! -f "build/index.html" ]]; then
+            echo "Error: index.html not found in build directory"
+            exit 1
+          fi
+          
+          if [[ ! -f "build/metadata.json" ]]; then
+            echo "Error: metadata.json not found in build directory"
+            exit 1
+          fi
+          
+          # Validate metadata.json
+          if ! jq empty build/metadata.json; then
+            echo "Error: metadata.json is not valid JSON"
+            exit 1
           fi
 
       - name: Commit metadata if changed

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,9 @@
 build/
 
 # Generated files
-*.html
-*.pdf
-*.pptx
+/build/**/*.html
+/build/**/*.pdf
+/build/**/*.pptx
 
 # OS-specific files
 .DS_Store

--- a/index.html
+++ b/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Presentations | Marp Collection</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = {
+            darkMode: 'class',
+            theme: {
+                extend: {
+                    animation: {
+                        'pulse-slow': 'pulse 3s cubic-bezier(0.4, 0, 0.6, 1) infinite',
+                    }
+                }
+            }
+        }
+    </script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+</head>
+<body class="h-full bg-white dark:bg-gray-900 transition-colors duration-200">
+    <div class="min-h-full flex flex-col">
+        <!-- Header -->
+        <header class="bg-white dark:bg-gray-800 shadow">
+            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex justify-between items-center">
+                <h1 class="text-2xl font-bold text-gray-900 dark:text-white">
+                    <i class="fas fa-file-powerpoint mr-2"></i>
+                    Presentations
+                </h1>
+                <button id="darkModeToggle" class="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">
+                    <i class="fas fa-moon dark:text-white"></i>
+                </button>
+            </div>
+        </header>
+
+        <!-- Main Content -->
+        <main class="flex-grow">
+            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+                <div id="content" class="text-center text-gray-600 dark:text-gray-400">
+                    Loading presentations...
+                </div>
+            </div>
+        </main>
+
+        <!-- Footer -->
+        <footer class="bg-white dark:bg-gray-800 shadow">
+            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+                <div class="flex justify-between items-center">
+                    <p class="text-gray-600 dark:text-gray-400">
+                        <a href="https://github.com/fumiya-kume/presentation" class="hover:text-gray-900 dark:hover:text-white">
+                            <i class="fab fa-github mr-2"></i>
+                            View on GitHub
+                        </a>
+                    </p>
+                    <p class="text-gray-500 dark:text-gray-400 text-sm">
+                        Built with Marp
+                    </p>
+                </div>
+            </div>
+        </footer>
+    </div>
+
+    <script>
+        // Dark mode toggle
+        const darkModeToggle = document.getElementById('darkModeToggle');
+        darkModeToggle.addEventListener('click', () => {
+            document.documentElement.classList.toggle('dark');
+            localStorage.setItem('darkMode', document.documentElement.classList.contains('dark'));
+        });
+
+        // Initialize dark mode from localStorage
+        if (localStorage.getItem('darkMode') === 'true' ||
+            (!localStorage.getItem('darkMode') && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+            document.documentElement.classList.add('dark');
+        }
+    </script>
+</body>
+</html> 


### PR DESCRIPTION
# Add Base Index Page Template

This PR adds the initial index page template with basic structure and dark mode support.

## Changes

- Add basic index.html template with:
  - Responsive layout structure
  - Dark mode support with system preference detection
  - Basic header with dark mode toggle
  - Simple footer with repository link
  - Tailwind CSS for styling
  - Font Awesome for icons

- Update workflow to:
  - Copy index.html to build directory
  - Handle paths for PR previews
  - Validate build requirements
  - Ensure proper deployment

## Implementation Details

The index page currently includes:
- Basic responsive layout
- Dark mode toggle that persists in localStorage
- System dark mode preference detection
- Placeholder for presentation content
- GitHub repository link

## Testing

- Verify that the page loads correctly
- Test dark mode toggle
- Check responsive layout
- Confirm GitHub link works
- Verify PR preview paths are correct

This is the first step in implementing the presentation index. Future PRs will add:
1. Presentation cards and data loading
2. Search and filter functionality
3. Additional features and polish 