### PR TITLE
Exclude README.md from Marp processing

### DIFF
--- a/.github/workflows/marp-to-pages.yml
+++ b/.github/workflows/marp-to-pages.yml
@@ -168,11 +168,24 @@ jobs:
       - name: Commit metadata if changed
         if: steps.process.outputs.has_changes == 'true'
         run: |
+          # Configure git
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
+          
+          # Get current branch name or use master for detached HEAD
+          BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+          if [ "$BRANCH_NAME" = "HEAD" ]; then
+            if [ "${{ github.event_name }}" = "pull_request" ]; then
+              BRANCH_NAME="${{ github.head_ref }}"
+            else
+              BRANCH_NAME="master"
+            fi
+          fi
+          
+          # Commit and push changes
           git add metadata.json
           git commit -m "Update metadata.json [skip ci]"
-          git push
+          git push origin HEAD:$BRANCH_NAME
 
       - name: Deploy preview
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/marp-to-pages.yml
+++ b/.github/workflows/marp-to-pages.yml
@@ -27,7 +27,7 @@ jobs:
         id: find-md
         run: |
           # Find all Marp markdown files and convert to JSON array
-          files=$(find . -type f -name "*.md" ! -path "./.github/*" ! -path "./build/*" -exec grep -l "marp: true" {} \; | \
+          files=$(find . -type f -name "*.md" ! -path "./.github/*" ! -path "./build/*" ! -name "README.md" -exec grep -l "marp: true" {} \; | \
                  sed -e 's|^\./||' | jq -R -s -c 'split("\n")[:-1]')
           echo "Found files: $files"
           echo "files=$files" >> $GITHUB_OUTPUT

--- a/metadata.json
+++ b/metadata.json
@@ -9,16 +9,6 @@
         "html": "DB history in Mobile App/presentation.html",
         "pdf": "DB history in Mobile App/presentation.pdf"
       }
-    },
-    {
-      "title": "Presentations",
-      "path": "README",
-      "description": "This repository contains various presentations created using Marp.",
-      "lastModified": "2025-02-16T16:33:50+09:00",
-      "formats": {
-        "html": "README.html",
-        "pdf": "README.pdf"
-      }
     }
   ]
 }


### PR DESCRIPTION
# Exclude README.md from Marp Processing

This PR updates the workflow to exclude README.md from being processed as a Marp presentation.

## Changes

- Add `! -name "README.md"` to the find command in the workflow
- This prevents README.md from being:
  - Processed as a presentation
  - Included in metadata.json
  - Generated as HTML/PDF/PPTX

## Testing

- [ ] Verify README.md is not processed as a presentation
- [ ] Check that other markdown files with `marp: true` are still processed
- [ ] Ensure metadata.json doesn't include README.md
- [ ] Confirm no regression in other functionality

## Impact

This change will:
- Fix the issue of README.md being treated as a presentation
- Reduce unnecessary file generation
- Keep the presentation list focused on actual presentations 