### PR TITLE
Add slide detail pages

### DIFF
--- a/.github/workflows/marp-to-pages.yml
+++ b/.github/workflows/marp-to-pages.yml
@@ -33,7 +33,10 @@ jobs:
           echo "files=$files" >> $GITHUB_OUTPUT
 
       - name: Create build directory
-        run: mkdir -p build
+        run: |
+          mkdir -p build
+          # Copy detail page files
+          cp -r detail/* build/
 
       - name: Copy index page
         run: |
@@ -42,6 +45,7 @@ jobs:
           # Update paths for preview if needed
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             sed -i "s|metadata.json|pr-preview/${{ github.event.number }}/metadata.json|g" build/index.html
+            sed -i "s|metadata.json|pr-preview/${{ github.event.number }}/metadata.json|g" build/detail.html
           fi
 
       - name: Process markdown files and generate metadata
@@ -102,7 +106,8 @@ jobs:
                 lastModified: $lastModified,
                 formats: {
                   html: ($path + ".html"),
-                  pdf: ($path + ".pdf")
+                  pdf: ($path + ".pdf"),
+                  pptx: ($path + ".pptx")
                 }
               }'
           }

--- a/detail/detail.css
+++ b/detail/detail.css
@@ -1,0 +1,61 @@
+/* Animation for loading spinner */
+@keyframes pulse-slow {
+    0%, 100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: .5;
+    }
+}
+
+.animate-pulse-slow {
+    animation: pulse-slow 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+/* Format link hover effects */
+.format-link {
+    transform: translateY(0);
+    transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+}
+
+.format-link:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+}
+
+/* Navigation button hover effects */
+.nav-button {
+    transition: transform 0.2s ease-in-out;
+}
+
+.nav-button:hover {
+    transform: translateX(0);
+}
+
+.nav-button:hover:first-child {
+    transform: translateX(-4px);
+}
+
+.nav-button:hover:last-child {
+    transform: translateX(4px);
+}
+
+/* Dark mode specific styles */
+.dark .format-link {
+    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.1);
+}
+
+.dark .format-link:hover {
+    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.2), 0 4px 6px -1px rgba(0, 0, 0, 0.5);
+}
+
+/* Responsive adjustments */
+@media (max-width: 640px) {
+    .format-links {
+        gap: 1rem;
+    }
+    
+    .nav-button {
+        padding: 0.5rem 1rem;
+    }
+}

--- a/detail/detail.html
+++ b/detail/detail.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Presentation Details | Marp Collection</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <link rel="stylesheet" href="detail.css">
+</head>
+<body class="h-full bg-white dark:bg-gray-900 transition-colors duration-200">
+    <div class="min-h-full flex flex-col">
+        <!-- Header with breadcrumb -->
+        <header class="bg-white dark:bg-gray-800 shadow">
+            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+                <div class="flex justify-between items-center">
+                    <nav class="flex" aria-label="Breadcrumb">
+                        <ol class="flex items-center space-x-4">
+                            <li>
+                                <a href="index.html" class="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white">
+                                    <i class="fas fa-home"></i>
+                                </a>
+                            </li>
+                            <li class="flex items-center">
+                                <i class="fas fa-chevron-right text-gray-400"></i>
+                                <span id="presentationPath" class="ml-4 text-gray-900 dark:text-white font-medium"></span>
+                            </li>
+                        </ol>
+                    </nav>
+                    <button id="darkModeToggle" class="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">
+                        <i class="fas fa-moon dark:text-white"></i>
+                    </button>
+                </div>
+            </div>
+        </header>
+
+        <!-- Main content -->
+        <main class="flex-grow">
+            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+                <!-- Loading state -->
+                <div id="loadingState" class="text-center py-12">
+                    <div class="animate-pulse-slow">
+                        <i class="fas fa-circle-notch fa-spin fa-2x text-gray-600 dark:text-gray-400"></i>
+                        <p class="mt-4 text-gray-600 dark:text-gray-400">Loading presentation details...</p>
+                    </div>
+                </div>
+
+                <!-- Error state -->
+                <div id="errorState" class="hidden text-center py-12">
+                    <div class="text-red-600 dark:text-red-400">
+                        <i class="fas fa-exclamation-circle fa-2x"></i>
+                        <p id="errorMessage" class="mt-4">Failed to load presentation details</p>
+                        <a href="index.html" class="mt-4 inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors">
+                            Return to Index
+                        </a>
+                    </div>
+                </div>
+
+                <!-- Presentation details -->
+                <div id="presentationDetails" class="hidden">
+                    <article class="bg-white dark:bg-gray-800 rounded-lg shadow-lg overflow-hidden">
+                        <div class="p-6">
+                            <h1 id="presentationTitle" class="text-3xl font-bold text-gray-900 dark:text-white mb-4"></h1>
+                            <p id="presentationDescription" class="text-gray-600 dark:text-gray-400 mb-8"></p>
+                            
+                            <div class="border-t border-gray-200 dark:border-gray-700 pt-6">
+                                <h2 class="text-xl font-semibold text-gray-900 dark:text-white mb-4">Available Formats</h2>
+                                <div class="format-links grid grid-cols-1 md:grid-cols-3 gap-4">
+                                    <template id="formatLinkTemplate">
+                                        <a href="#" class="format-link flex items-center p-4 rounded-lg transition-colors">
+                                            <i class="format-icon text-2xl mr-4"></i>
+                                            <div>
+                                                <div class="font-medium format-title"></div>
+                                                <div class="text-sm format-subtitle"></div>
+                                            </div>
+                                        </a>
+                                    </template>
+                                </div>
+                            </div>
+
+                            <div class="mt-8 text-sm text-gray-500 dark:text-gray-400">
+                                Last updated: <time id="lastModified"></time>
+                            </div>
+                        </div>
+                    </article>
+
+                    <!-- Navigation -->
+                    <nav class="presentation-nav mt-8 flex justify-between items-center">
+                        <template id="navButtonTemplate">
+                            <a href="#" class="nav-button flex items-center px-4 py-2 bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors">
+                                <i class="nav-icon mr-2"></i>
+                                <span class="nav-text"></span>
+                            </a>
+                        </template>
+                    </nav>
+                </div>
+            </div>
+        </main>
+
+        <!-- Footer -->
+        <footer class="bg-white dark:bg-gray-800 shadow">
+            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+                <div class="flex justify-between items-center">
+                    <p class="text-gray-600 dark:text-gray-400">
+                        <a href="https://github.com/fumiya-kume/presentation" class="hover:text-gray-900 dark:hover:text-white">
+                            <i class="fab fa-github mr-2"></i>
+                            View on GitHub
+                        </a>
+                    </p>
+                    <p class="text-gray-500 dark:text-gray-400 text-sm">
+                        Built with Marp
+                    </p>
+                </div>
+            </div>
+        </footer>
+    </div>
+
+    <script src="detail.js"></script>
+</body>
+</html>

--- a/detail/detail.js
+++ b/detail/detail.js
@@ -1,0 +1,244 @@
+// Utility functions
+function formatDate(dateString) {
+    const date = new Date(dateString);
+    const now = new Date();
+    const diff = now - date;
+    const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+
+    if (days < 1) return 'Today';
+    if (days === 1) return 'Yesterday';
+    if (days < 7) return `${days} days ago`;
+    if (days < 30) return `${Math.floor(days / 7)} weeks ago`;
+    
+    return date.toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric'
+    });
+}
+
+// State Management
+class PresentationState {
+    constructor() {
+        this.presentations = [];
+        this.currentIndex = -1;
+    }
+
+    async initialize() {
+        await this.loadPresentations();
+        this.setupEventListeners();
+    }
+
+    async loadPresentations() {
+        const response = await fetch('../metadata.json');
+        if (!response.ok) throw new Error('Failed to load presentations');
+        
+        const data = await response.json();
+        this.presentations = data.presentations.sort(
+            (a, b) => new Date(b.lastModified) - new Date(a.lastModified)
+        );
+    }
+
+    findPresentationIndex(path) {
+        return this.presentations.findIndex(p => p.path === path);
+    }
+
+    getNavigation(currentPath) {
+        const currentIndex = this.findPresentationIndex(currentPath);
+        return {
+            prev: currentIndex > 0 ? this.presentations[currentIndex - 1] : null,
+            next: currentIndex < this.presentations.length - 1 
+                  ? this.presentations[currentIndex + 1] 
+                  : null
+        };
+    }
+
+    setupEventListeners() {
+        // Handle browser back/forward buttons
+        window.addEventListener('popstate', () => {
+            this.loadPresentationFromUrl();
+        });
+    }
+}
+
+// Detail Page Controller
+class DetailPageController {
+    constructor() {
+        this.state = new PresentationState();
+        this.elements = {
+            title: document.getElementById('presentationTitle'),
+            description: document.getElementById('presentationDescription'),
+            lastModified: document.getElementById('lastModified'),
+            path: document.getElementById('presentationPath'),
+            formatLinks: document.querySelector('.format-links'),
+            navigation: document.querySelector('.presentation-nav'),
+            loadingState: document.getElementById('loadingState'),
+            errorState: document.getElementById('errorState'),
+            presentationDetails: document.getElementById('presentationDetails'),
+            darkModeToggle: document.getElementById('darkModeToggle')
+        };
+        
+        this.setupDarkMode();
+    }
+
+    async initialize() {
+        this.showLoading();
+        try {
+            await this.state.initialize();
+            await this.loadPresentationFromUrl();
+        } catch (error) {
+            console.error('Initialization error:', error);
+            this.showError(error.message);
+        }
+    }
+
+    setupDarkMode() {
+        const darkModeToggle = this.elements.darkModeToggle;
+        const moonIcon = darkModeToggle.querySelector('i');
+
+        const updateDarkModeIcon = (isDark) => {
+            moonIcon.className = isDark ? 'fas fa-sun text-white' : 'fas fa-moon';
+        };
+
+        darkModeToggle.addEventListener('click', () => {
+            const isDark = document.documentElement.classList.toggle('dark');
+            localStorage.setItem('darkMode', isDark);
+            updateDarkModeIcon(isDark);
+        });
+
+        // Initialize dark mode from localStorage or system preference
+        const isDark = localStorage.getItem('darkMode') === 'true' ||
+            (!localStorage.getItem('darkMode') && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        
+        if (isDark) {
+            document.documentElement.classList.add('dark');
+        }
+        updateDarkModeIcon(isDark);
+    }
+
+    async loadPresentationFromUrl() {
+        const params = new URLSearchParams(window.location.search);
+        const presentationId = params.get('id');
+        
+        if (!presentationId) {
+            this.showError('No presentation specified');
+            return;
+        }
+        
+        const presentation = this.state.presentations.find(
+            p => p.path === presentationId
+        );
+        
+        if (!presentation) {
+            this.showError('Presentation not found');
+            return;
+        }
+        
+        this.renderPresentation(presentation);
+    }
+
+    showLoading() {
+        this.elements.loadingState.classList.remove('hidden');
+        this.elements.errorState.classList.add('hidden');
+        this.elements.presentationDetails.classList.add('hidden');
+    }
+
+    showError(message) {
+        this.elements.loadingState.classList.add('hidden');
+        this.elements.errorState.classList.remove('hidden');
+        this.elements.presentationDetails.classList.add('hidden');
+        document.getElementById('errorMessage').textContent = message;
+    }
+
+    showContent() {
+        this.elements.loadingState.classList.add('hidden');
+        this.elements.errorState.classList.add('hidden');
+        this.elements.presentationDetails.classList.remove('hidden');
+    }
+
+    renderPresentation(presentation) {
+        // Update metadata
+        document.title = `${presentation.title} | Marp Collection`;
+        this.elements.title.textContent = presentation.title;
+        this.elements.description.textContent = presentation.description;
+        this.elements.lastModified.textContent = formatDate(presentation.lastModified);
+        this.elements.path.textContent = presentation.path;
+        
+        // Render format links
+        this.renderFormatLinks(presentation.formats);
+        
+        // Render navigation
+        this.renderNavigation(presentation.path);
+        
+        // Show content
+        this.showContent();
+    }
+
+    renderFormatLinks(formats) {
+        const template = document.getElementById('formatLinkTemplate');
+        this.elements.formatLinks.innerHTML = '';
+        
+        const formatConfig = {
+            html: {
+                icon: 'fa-globe',
+                title: 'View Online',
+                subtitle: 'HTML Format',
+                classes: 'bg-blue-50 dark:bg-blue-900 text-blue-900 dark:text-blue-100'
+            },
+            pdf: {
+                icon: 'fa-file-pdf',
+                title: 'Download',
+                subtitle: 'PDF Format',
+                classes: 'bg-red-50 dark:bg-red-900 text-red-900 dark:text-red-100'
+            },
+            pptx: {
+                icon: 'fa-file-powerpoint',
+                title: 'Download',
+                subtitle: 'PowerPoint Format',
+                classes: 'bg-orange-50 dark:bg-orange-900 text-orange-900 dark:text-orange-100'
+            }
+        };
+        
+        Object.entries(formats).forEach(([format, url]) => {
+            const config = formatConfig[format];
+            if (!config) return;
+            
+            const link = template.content.cloneNode(true).querySelector('.format-link');
+            link.href = url;
+            link.classList.add(...config.classes.split(' '));
+            link.querySelector('.format-icon').classList.add('fas', config.icon);
+            link.querySelector('.format-title').textContent = config.title;
+            link.querySelector('.format-subtitle').textContent = config.subtitle;
+            
+            this.elements.formatLinks.appendChild(link);
+        });
+    }
+
+    renderNavigation(currentPath) {
+        const { prev, next } = this.state.getNavigation(currentPath);
+        const template = document.getElementById('navButtonTemplate');
+        this.elements.navigation.innerHTML = '';
+        
+        if (prev) {
+            const prevButton = template.content.cloneNode(true).querySelector('.nav-button');
+            prevButton.href = `detail.html?id=${encodeURIComponent(prev.path)}`;
+            prevButton.querySelector('.nav-icon').classList.add('fas', 'fa-chevron-left');
+            prevButton.querySelector('.nav-text').textContent = 'Previous';
+            this.elements.navigation.appendChild(prevButton);
+        }
+        
+        if (next) {
+            const nextButton = template.content.cloneNode(true).querySelector('.nav-button');
+            nextButton.href = `detail.html?id=${encodeURIComponent(next.path)}`;
+            nextButton.querySelector('.nav-icon').classList.add('fas', 'fa-chevron-right');
+            nextButton.querySelector('.nav-text').textContent = 'Next';
+            this.elements.navigation.appendChild(nextButton);
+        }
+    }
+}
+
+// Initialize the page
+document.addEventListener('DOMContentLoaded', () => {
+    const controller = new DetailPageController();
+    controller.initialize().catch(console.error);
+});

--- a/index.html
+++ b/index.html
@@ -146,7 +146,8 @@
                 <article class="bg-white dark:bg-gray-800 rounded-lg shadow-lg overflow-hidden hover:shadow-xl transition-shadow duration-200">
                     <div class="p-6">
                         <h2 class="text-xl font-bold text-gray-900 dark:text-white mb-2">
-                            <a href="${presentation.formats.html}" class="hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
+                            <a href="detail.html?id=${encodeURIComponent(presentation.path)}" 
+                               class="hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
                                 ${escapeHtml(presentation.title)}
                             </a>
                         </h2>
@@ -158,6 +159,11 @@
                                 ${formatDate(presentation.lastModified)}
                             </time>
                             <div class="space-x-2">
+                                <a href="detail.html?id=${encodeURIComponent(presentation.path)}" 
+                                   class="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 transition-colors"
+                                   title="View Details">
+                                    <i class="fas fa-info-circle"></i>
+                                </a>
                                 <a href="${presentation.formats.html}" 
                                    class="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 transition-colors"
                                    title="View Online">

--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,8 @@
       "lastModified": "2025-02-16T16:06:29+09:00",
       "formats": {
         "html": "DB history in Mobile App/presentation.html",
-        "pdf": "DB history in Mobile App/presentation.pdf"
+        "pdf": "DB history in Mobile App/presentation.pdf",
+        "pptx": "DB history in Mobile App/presentation.pptx"
       }
     }
   ]


### PR DESCRIPTION
# Add Slide Detail Pages

This PR adds detail pages for presentations with enhanced navigation and format options.

## Features

- Individual detail page for each presentation
- Responsive design with dark mode support
- Format options (HTML, PDF, PPTX)
- Navigation between presentations
- Breadcrumb navigation
- Loading and error states
- Back/forward button support

## Changes

- Add `detail/` directory with:
  - `detail.html` - Main template
  - `detail.css` - Additional styles
  - `detail.js` - JavaScript functionality
- Update workflow to copy detail files
- Modify index page to link to detail pages
- Add "View Details" button to presentation cards

## Testing

- [ ] Detail page loads correctly
- [ ] All format links work
- [ ] Dark mode persists between pages
- [ ] Navigation works (prev/next)
- [ ] Loading/error states display correctly
- [ ] Responsive on all screen sizes
- [ ] URLs are shareable
- [ ] Back button works
- [ ] Preview deployment works

## Screenshots

Will be added after the preview deployment is complete. 