### PR TITLE
Fix detail page metadata loading

### DIFF
--- a/detail/detail.js
+++ b/detail/detail.js
@@ -30,13 +30,27 @@ class PresentationState {
     }
 
     async loadPresentations() {
-        const response = await fetch('../metadata.json');
-        if (!response.ok) throw new Error('Failed to load presentations');
-        
-        const data = await response.json();
-        this.presentations = data.presentations.sort(
-            (a, b) => new Date(b.lastModified) - new Date(a.lastModified)
-        );
+        try {
+            const response = await fetch('metadata.json');  // Updated path
+            if (!response.ok) {
+                throw new Error(`Failed to load metadata (Status: ${response.status})`);
+            }
+            
+            const data = await response.json();
+            if (!data.presentations || !Array.isArray(data.presentations)) {
+                throw new Error('Invalid metadata format: missing presentations array');
+            }
+
+            this.presentations = data.presentations.sort(
+                (a, b) => new Date(b.lastModified) - new Date(a.lastModified)
+            );
+        } catch (error) {
+            console.error('Error loading presentations:', error);
+            throw new Error(
+                `Failed to load presentation data: ${error.message}. ` +
+                'Please try refreshing the page or return to the index page.'
+            );
+        }
     }
 
     findPresentationIndex(path) {


### PR DESCRIPTION
# Fix Detail Page Metadata Loading

This PR fixes the issue where the detail page fails to load presentation data with a "Failed to load presentations" error.

## Changes

- Fix metadata.json path in detail.js
  - Change from `../metadata.json` to `metadata.json`
  - Both files are in the same build directory

- Improve error handling
  - Add more descriptive error messages
  - Include HTTP status code in error message
  - Validate metadata format
  - Add helpful user instructions in error messages

## Testing

- [ ] Detail page loads presentation data correctly
- [ ] Error messages are clear and helpful
- [ ] Navigation between presentations works
- [ ] All format links work correctly
- [ ] Back to index link works
- [ ] Preview deployment works correctly 